### PR TITLE
既存の行と行の間に、新規の行を追加できるようにする。

### DIFF
--- a/src/components/EditorContainer.tsx
+++ b/src/components/EditorContainer.tsx
@@ -1,5 +1,5 @@
 // TODO: コンポーネントを分割してリファクタリングする
-import AddIcon from '@mui/icons-material/Add';
+import AddCircleRoundedIcon from '@mui/icons-material/AddCircleRounded';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import DeleteIcon from '@mui/icons-material/Delete';
 import MenuIcon from '@mui/icons-material/Menu';
@@ -225,18 +225,21 @@ export default function EditorContainer() {
   };
 
   const addLine = () => {
-    setLines([
-      ...lines,
-      {
-        ...lines[lines.length - 1],
-        text: '',
-        moraToneList: [],
-        accentModified: false,
-      },
-    ]);
-    setCurrentLineIndex(lines.length);
-  };
+  const addLineAt = (index: number) => {
+      const newLine = {
+          ...lines[index],
+          text: '',
+          moraToneList: [],
+          accentModified: false,
+      };
 
+      const newLines = [...lines];
+      newLines.splice(index + 1, 0, newLine);
+
+      setLines(newLines);
+      setCurrentLineIndex(index + 1);
+  };
+  
   const setLineState = (newState: Partial<LineState>) => {
     const newLines = lines.map((line, index) => {
       if (index === currentLineIndex) {
@@ -342,7 +345,7 @@ export default function EditorContainer() {
       if (currentLineIndex < lines.length - 1) {
         setCurrentLineIndex(currentLineIndex + 1);
       } else {
-        addLine();
+        addLineAt(currentLineIndex);
       }
     } else if (e.key === 'ArrowUp') {
       if (currentLineIndex > 0) {
@@ -501,6 +504,12 @@ export default function EditorContainer() {
                   '&:hover .delete-button': {
                     display: 'block',
                   },
+                  '& .add-line-button': {
+                    display: 'none',
+                  },
+                  '&:hover .add-line-button': {
+                    display: 'block',
+                  },
                 }}
               >
                 <Grid xs='auto'>
@@ -533,20 +542,22 @@ export default function EditorContainer() {
                     className='delete-button'
                     disabled={lines.length === 1}
                     onClick={() => handleDelete(index)}
+                    title='この行を削除する'
                   >
                     <DeleteIcon />
                   </IconButton>
                 </Grid>
+                <Grid xs='auto'>
+                  <IconButton
+                      className='add-line-button'
+                      onClick={() => addLineAt(index)}
+                      title='行を追加する'
+                  >
+                    <AddCircleRoundedIcon />
+                  </IconButton>
+                </Grid>
               </Grid>
             ))}
-            <Button
-              variant='outlined'
-              startIcon={<AddIcon />}
-              onClick={addLine}
-              sx={{ mt: 2 }}
-            >
-              テキスト追加
-            </Button>
           </Paper>
           <AccentEditor
             moraToneList={lines[currentLineIndex].moraToneList}


### PR DESCRIPTION
【改善したい点】行の追加が行配列の最後尾行われるため、既に複数行で文章が入力してある状況下で、行と行の間に文章を追加することが簡単にはできない。
【改善方法】各行の「削除ボタン」と並びで「追加ボタン」を配置。その追加ボタンを押下すると、その行の「次の行」として新規の行を追加する。