### PR TITLE
特定の日本語入力環境で、入力ができないのを修正

### DIFF
--- a/src/components/EditorContainer.tsx
+++ b/src/components/EditorContainer.tsx
@@ -120,9 +120,9 @@ export default function EditorContainer() {
 
   const { height } = useWindowSize();
 
-  const [composing, setComposition] = useState(false);
-  const startComposition = () => setComposition(true);
-  const endComposition = () => setComposition(false);
+  const composing = useRef<boolean>(false);
+  const startComposition = () => (composing.current = true);
+  const endComposition = () => (composing.current = false);
   const refs = useRef<HTMLTextAreaElement[]>([]);
 
   useEffect(() => {
@@ -353,7 +353,7 @@ export default function EditorContainer() {
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
-    if (e.key === 'Enter' && !composing) {
+    if (e.key === 'Enter' && !composing.current) {
       handleSynthesis();
     } else if (e.key === 'ArrowDown') {
       if (currentLineIndex < lines.length - 1) {


### PR DESCRIPTION
* OS: Windows 11
* ブラウザ: Firefox
* 日本語入力: CorvusSKK
上記の環境で、読み上げ内容のテキストボックスに、ひらがな・漢字を入力できないのを修正するPRです。

onCompositionStart が呼ばれてから onCompositionEnd が呼ばれるまでが極端に短い (Date.now() 読みで1ミリ秒) のが原因かと考えています。